### PR TITLE
Crippling defeat total replenishment change

### DIFF
--- a/data/juggernaut/function/hooks/jug_killed_player.mcfunction
+++ b/data/juggernaut/function/hooks/jug_killed_player.mcfunction
@@ -1,6 +1,6 @@
 execute if entity @s[tag=using_pressure_point] as @a[tag=runner,tag=!undetectable] if entity @s[nbt=!{active_effects:[{id:"minecraft:invisibility"}]}] run effect give @s glowing 12 0 true
 
-execute if entity @s[tag=using_crippling_defeat] as @n[type=armor_stand,tag=replenishment.station,tag=highest_station] run function juggernaut:replenishment_management/regress_station {percentage:75}
+execute if entity @s[tag=using_crippling_defeat] as @n[type=armor_stand,tag=replenishment.station,tag=highest_station] run function juggernaut:replenishment_management/regress_station_total {percentage:25}
 
 execute if entity @s[tag=using_bloodlust] run scoreboard players set @s bloodlust_remaining 45
 

--- a/data/juggernaut/function/replenishment_management/regress_station_total.mcfunction
+++ b/data/juggernaut/function/replenishment_management/regress_station_total.mcfunction
@@ -1,0 +1,13 @@
+# Regress a station by a percentage of a station's TOTAL capacity (not its current value).
+# ONE PERCENT = TOTAL / 100
+# X PERCENT = ONE PERCENT * X
+scoreboard players set #regress_amount var 0
+scoreboard players operation #regress_amount var = #total_replenishment_per_station var
+scoreboard players operation #regress_amount var /= #100 var
+$scoreboard players operation #regress_amount var *= #$(percentage) var
+
+# Never remove more than the station currently holds, so it can't drop below empty.
+execute if score #regress_amount var > @s replenish_amount run scoreboard players operation #regress_amount var = @s replenish_amount
+
+scoreboard players operation #juggernaut_manager replenish_progress -= #regress_amount var
+scoreboard players operation @s replenish_amount -= #regress_amount var


### PR DESCRIPTION
Made crippling defeat regress a percentage of the total station, rather than of the current replenishment